### PR TITLE
Fix: Prevent the participants from casting multiple votes

### DIFF
--- a/anchor/target/idl/voting.json
+++ b/anchor/target/idl/voting.json
@@ -169,6 +169,38 @@
           }
         },
         {
+          "name": "participant",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  112,
+                  97,
+                  114,
+                  116,
+                  105,
+                  99,
+                  105,
+                  112,
+                  97,
+                  110,
+                  116
+                ]
+              },
+              {
+                "kind": "arg",
+                "path": "poll_id"
+              },
+              {
+                "kind": "account",
+                "path": "signer"
+              }
+            ]
+          }
+        },
+        {
           "name": "system_program",
           "address": "11111111111111111111111111111111"
         }
@@ -179,7 +211,7 @@
           "type": "string"
         },
         {
-          "name": "_poll_id",
+          "name": "poll_id",
           "type": "u64"
         }
       ]
@@ -200,6 +232,19 @@
       ]
     },
     {
+      "name": "Participant",
+      "discriminator": [
+        32,
+        142,
+        108,
+        79,
+        247,
+        179,
+        54,
+        6
+      ]
+    },
+    {
       "name": "Poll",
       "discriminator": [
         110,
@@ -211,6 +256,13 @@
         153,
         111
       ]
+    }
+  ],
+  "errors": [
+    {
+      "code": 6000,
+      "name": "AlreadyVoted",
+      "msg": "You have already voted in this poll"
     }
   ],
   "types": [
@@ -226,6 +278,26 @@
           {
             "name": "candidate_votes",
             "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "Participant",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "participant",
+            "type": "pubkey"
+          },
+          {
+            "name": "poll_id",
+            "type": "u64"
+          },
+          {
+            "name": "has_voted",
+            "type": "bool"
           }
         ]
       }

--- a/anchor/target/types/voting.ts
+++ b/anchor/target/types/voting.ts
@@ -175,6 +175,38 @@ export type Voting = {
           }
         },
         {
+          "name": "participant",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  112,
+                  97,
+                  114,
+                  116,
+                  105,
+                  99,
+                  105,
+                  112,
+                  97,
+                  110,
+                  116
+                ]
+              },
+              {
+                "kind": "arg",
+                "path": "pollId"
+              },
+              {
+                "kind": "account",
+                "path": "signer"
+              }
+            ]
+          }
+        },
+        {
           "name": "systemProgram",
           "address": "11111111111111111111111111111111"
         }
@@ -206,6 +238,19 @@ export type Voting = {
       ]
     },
     {
+      "name": "participant",
+      "discriminator": [
+        32,
+        142,
+        108,
+        79,
+        247,
+        179,
+        54,
+        6
+      ]
+    },
+    {
       "name": "poll",
       "discriminator": [
         110,
@@ -217,6 +262,13 @@ export type Voting = {
         153,
         111
       ]
+    }
+  ],
+  "errors": [
+    {
+      "code": 6000,
+      "name": "alreadyVoted",
+      "msg": "You have already voted in this poll"
     }
   ],
   "types": [
@@ -232,6 +284,26 @@ export type Voting = {
           {
             "name": "candidateVotes",
             "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "participant",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "participant",
+            "type": "pubkey"
+          },
+          {
+            "name": "pollId",
+            "type": "u64"
+          },
+          {
+            "name": "hasVoted",
+            "type": "bool"
           }
         ]
       }

--- a/anchor/tests/voting.spec.ts
+++ b/anchor/tests/voting.spec.ts
@@ -76,14 +76,11 @@ describe("Voting", () => {
       "Pink",
       new anchor.BN(1),
     ).rpc();
-    await votingProgram.methods.vote(
-      "Blue",
-      new anchor.BN(1),
-    ).rpc();
-    await votingProgram.methods.vote(
-      "Pink",
-      new anchor.BN(1),
-    ).rpc();
+    // This will now fail because the participant has already voted and we cannot use the same keypair to vote for second candidate i.e. blue
+    // await votingProgram.methods.vote(
+    //   "Blue",
+    //   new anchor.BN(1),
+    // ).rpc();
 
     const [pinkAddress] = PublicKey.findProgramAddressSync(
       [new anchor.BN(1).toArrayLike(Buffer, "le", 8), Buffer.from("Pink")],
@@ -91,16 +88,16 @@ describe("Voting", () => {
     );
     const pinkCandidate = await votingProgram.account.candidate.fetch(pinkAddress);
     console.log(pinkCandidate);
-    expect(pinkCandidate.candidateVotes.toNumber()).toBe(2);
+    expect(pinkCandidate.candidateVotes.toNumber()).toBe(1);
     expect(pinkCandidate.candidateName).toBe("Pink");
 
-    const [blueAddress] = PublicKey.findProgramAddressSync(
-      [new anchor.BN(1).toArrayLike(Buffer, "le", 8), Buffer.from("Blue")],
-      votingProgram.programId,
-    );
-    const blueCandidate = await votingProgram.account.candidate.fetch(blueAddress);
-    console.log(blueCandidate);
-    expect(blueCandidate.candidateVotes.toNumber()).toBe(1);
-    expect(blueCandidate.candidateName).toBe("Blue");
+    // const [blueAddress] = PublicKey.findProgramAddressSync(
+    //   [new anchor.BN(1).toArrayLike(Buffer, "le", 8), Buffer.from("Blue")],
+    //   votingProgram.programId,
+    // );
+    // const blueCandidate = await votingProgram.account.candidate.fetch(blueAddress);
+    // console.log(blueCandidate);
+    // expect(blueCandidate.candidateVotes.toNumber()).toBe(1);
+    // expect(blueCandidate.candidateName).toBe("Blue");
   });
 });


### PR DESCRIPTION
Fixes Issue #1

Email address: saakshiraut28@gmail.com

Changes address in the PR:
- Added a Participant account to track if a participant has already voted using a boolean flag.
- Updated the voting logic to prevent multiple votes from the same participant.
- Modified test cases to reflect the one-vote-per-participant constraint.
. 
 This pull request was created for https://app.gib.work/bounties/3a5baf2c-de61-402f-8eb5-fa43b6c18dc8 in an attempt to solve a bounty #1 . Payment for the bounty is immediately sent to the contributor after merge.