### PR TITLE
Fix: Prevent creation of polls having end_time in past

### DIFF
--- a/anchor/programs/voting/src/lib.rs
+++ b/anchor/programs/voting/src/lib.rs
@@ -1,6 +1,7 @@
 #![allow(clippy::result_large_err)]
 
 use anchor_lang::prelude::*;
+use anchor_lang::solana_program::clock::Clock;
 
 declare_id!("coUnmi3oBUtwtd9fjeAvSsJssXh5A5xyPbhpewyzRVF");
 
@@ -13,6 +14,11 @@ pub mod voting {
                             description: String,
                             poll_start: u64,
                             poll_end: u64) -> Result<()> {
+        // get the current time
+        let clock = Clock::get()?;
+
+        // poll end time must be greater than current time. you cannot end a poll in the past.
+        require!(poll_end > clock.unix_timestamp as u64, CustomError::PollEndInPast);
 
         let poll = &mut ctx.accounts.poll;
         poll.poll_id = poll_id;
@@ -124,4 +130,10 @@ pub struct Poll {
     pub poll_start: u64,
     pub poll_end: u64,
     pub candidate_amount: u64,
+}
+
+#[error_code]
+pub enum CustomError {
+    #[msg("Poll end time cannot be in the past.")]
+    PollEndInPast,
 }

--- a/anchor/target/idl/voting.json
+++ b/anchor/target/idl/voting.json
@@ -213,6 +213,13 @@
       ]
     }
   ],
+  "errors": [
+    {
+      "code": 6000,
+      "name": "PollEndInPast",
+      "msg": "Poll end time cannot be in the past."
+    }
+  ],
   "types": [
     {
       "name": "Candidate",

--- a/anchor/target/types/voting.ts
+++ b/anchor/target/types/voting.ts
@@ -219,6 +219,13 @@ export type Voting = {
       ]
     }
   ],
+  "errors": [
+    {
+      "code": 6000,
+      "name": "pollEndInPast",
+      "msg": "Poll end time cannot be in the past."
+    }
+  ],
   "types": [
     {
       "name": "candidate",

--- a/anchor/tests/voting.spec.ts
+++ b/anchor/tests/voting.spec.ts
@@ -25,7 +25,7 @@ describe("Voting", () => {
       new anchor.BN(1),
       "What is your favorite color?",
       new anchor.BN(100),
-      new anchor.BN(1739370789),
+      new anchor.BN(1744700218),
     ).rpc();
 
     const [pollAddress] = PublicKey.findProgramAddressSync(
@@ -40,6 +40,23 @@ describe("Voting", () => {
     expect(poll.pollId.toNumber()).toBe(1);
     expect(poll.description).toBe("What is your favorite color?");
     expect(poll.pollStart.toNumber()).toBe(100);
+  });
+
+  // Test to check if poll_end is in the past. It should FAIL as poll_end must be in the future.
+  it("fails if poll_end is less than current time", async () => {
+    const now = Math.floor(Date.now() / 1000);
+    try {
+      await votingProgram.methods.initializePoll(
+        new anchor.BN(2),
+        "Invalid end time test",
+        new anchor.BN(now + 100),         // start time in future
+        new anchor.BN(now - 1000),          // end time in the past
+      ).rpc();
+      throw new Error("Expected poll_end validation to fail");
+    } catch (err: any) {
+      console.log("Expected failure:", err.message);
+      expect(err.message).toMatch(/Poll end time cannot be in the past/);
+    }
   });
 
   it("initializes candidates", async () => {


### PR DESCRIPTION
Fix Issue #2

Email address: saakshiraut28@gmail.com

Changes address in this PR:
- Added a check to ensure that the `end_time` is not in the past.
- Updated the test accordingly.. 
 This pull request was created for https://app.gib.work/bounties/ce1da876-64b1-487e-a8dd-6b501e47c5fb in an attempt to solve a bounty #2 . Payment for the bounty is immediately sent to the contributor after merge.