### PR TITLE
Fix: Prevent Participants to vote before and after Polling Period

### DIFF
--- a/anchor/programs/voting/src/lib.rs
+++ b/anchor/programs/voting/src/lib.rs
@@ -42,6 +42,16 @@ pub mod voting {
     pub fn vote(ctx: Context<Vote>, _candidate_name: String, poll_id: u64) -> Result<()> {
         let candidate = &mut ctx.accounts.candidate;
         let participant = &mut ctx.accounts.participant;
+        let poll = &ctx.accounts.poll;
+
+        // get the current time
+        let clock = Clock::get()?;
+
+        // check if the poll is active. (poll_start < current_time)
+        require!(poll.poll_start < clock.unix_timestamp as u64, CustomError::PollIsNotActive);
+
+        // check if the poll is not ended (poll_end > current_time)
+        require!(poll.poll_end > clock.unix_timestamp as u64, CustomError::PollIsExpired);
 
         if participant.has_voted {
           return Err(error!(VotingError::AlreadyVoted));
@@ -161,7 +171,13 @@ pub struct Poll {
 pub enum CustomError {
     #[msg("Poll end time cannot be in the past.")]
     PollEndInPast,
+    #[msg("Poll is not started yet.")]
+    PollIsNotActive,
+    #[msg("Poll is expired.")]
+    PollIsExpired
+}
 
+#[error_code]
 pub enum VotingError {
     #[msg("You have already voted in this poll")]
     AlreadyVoted,

--- a/anchor/target/idl/voting.json
+++ b/anchor/target/idl/voting.json
@@ -263,8 +263,16 @@
       "code": 6000,
       "name": "PollEndInPast",
       "msg": "Poll end time cannot be in the past."
-      "name": "AlreadyVoted",
-      "msg": "You have already voted in this poll"
+    },
+    {
+      "code": 6001,
+      "name": "PollIsNotActive",
+      "msg": "Poll is not started yet."
+    },
+    {
+      "code": 6002,
+      "name": "PollIsExpired",
+      "msg": "Poll is expired."
     }
   ],
   "types": [

--- a/anchor/target/types/voting.ts
+++ b/anchor/target/types/voting.ts
@@ -269,8 +269,16 @@ export type Voting = {
       "code": 6000,
       "name": "pollEndInPast",
       "msg": "Poll end time cannot be in the past."
-      "name": "alreadyVoted",
-      "msg": "You have already voted in this poll"
+    },
+    {
+      "code": 6001,
+      "name": "pollIsNotActive",
+      "msg": "Poll is not started yet."
+    },
+    {
+      "code": 6002,
+      "name": "pollIsExpired",
+      "msg": "Poll is expired."
     }
   ],
   "types": [

--- a/anchor/tests/voting.spec.ts
+++ b/anchor/tests/voting.spec.ts
@@ -117,4 +117,55 @@ describe("Voting", () => {
     // expect(blueCandidate.candidateVotes.toNumber()).toBe(1);
     // expect(blueCandidate.candidateName).toBe("Blue");
   });
+
+  // Test if Poll is not started
+  it("fails to vote before poll start time", async () => {
+    const now = Math.floor(Date.now() / 1000);
+    await votingProgram.methods
+      .initializePoll(
+        new anchor.BN(3),
+        "What is your favorite fruit?",
+        new anchor.BN(now + 10000), // future start time
+        new anchor.BN(now + 20000) // future end time
+      )
+      .rpc();
+
+    await votingProgram.methods
+      .initializeCandidate("Mango", new anchor.BN(3))
+      .rpc();
+
+    try {
+      await votingProgram.methods.vote("Mango", new anchor.BN(3)).rpc();
+      throw new Error("Poll is not started yet, expected error not thrown");
+    } catch (err: any) {
+      console.log("Expected failure:", err.message);
+      expect(err.message).toMatch(/Poll is not started yet/);
+    }
+  });
+
+  // Test if Poll is already ended
+  it("fails to vote after poll end time", async () => {
+    const now = Math.floor(Date.now() / 1000);
+    await votingProgram.methods
+      .initializePoll(
+        new anchor.BN(4),
+        "What color is the sky?",
+        new anchor.BN(now - 10000),
+        new anchor.BN(now + 10) // keeping a very short time so that the poll ends quickly
+      )
+      .rpc();
+
+    await votingProgram.methods
+      .initializeCandidate("Blue", new anchor.BN(4))
+      .rpc();
+
+    try {
+      await votingProgram.methods.vote("Blue", new anchor.BN(4)).rpc();
+      throw new Error("Poll is already ended, expected error not thrown");
+    } catch (err: any) {
+      console.log("Expected failure:", err.message);
+      expect(err.message).toMatch(/Poll is already ended/);
+    }
+  });
+
 });


### PR DESCRIPTION
Fix Issue: #3

Email address: saakshiraut28@gmail.com

Changes address in this PR:

- Add a check to ensure voting happens only in the polling period
- Update the test accordingly. 
 This pull request was created for https://app.gib.work/bounties/dd4886fb-829c-4a36-ba44-958e406f091e in an attempt to solve a bounty #3 . Payment for the bounty is immediately sent to the contributor after merge.